### PR TITLE
Fix variable replacement on login page not working

### DIFF
--- a/views/login.pug
+++ b/views/login.pug
@@ -73,12 +73,12 @@ html
             #loginElementContainer.slds-form-element
               label.slds-form-element__label Login url
               div.slds-form-element__control
-                input#loginUrl.slds-input(type="text", size=60, value="#{defaultLoginUrl}")
+                input#loginUrl.slds-input(type="text", size=60, value=defaultLoginUrl)
 
             div.slds-form-element
               label.slds-form-element__label Connected app client id / Consumer key
               div.slds-form-element__control
-                input#clientId.slds-input(type="text", size=60, value="#{defaultConsumerKey}")
+                input#clientId.slds-input(type="text", size=60, value=defaultConsumerKey)
 
             .slds-form-element
               .slds-form-element__control


### PR DESCRIPTION
Pug was outputting the literal `value="#{defaultLoginUrl}"` instead of interpreting as a variable. Changing to use the variable directly fixes the issue.