### PR TITLE
Added layoutTypes param

### DIFF
--- a/client-src/sagas/recordFetcher.js
+++ b/client-src/sagas/recordFetcher.js
@@ -6,7 +6,7 @@ import { receiveRecord } from '../actions'
 export default function* recordFetcher (action) {
 
   // TODO: Add LayoutType to the state so that we can change view based on them
-  let recordViewUrl = action.creds.instanceUrl + '/services/data/v42.0/ui-api/record-ui/' + action.recordId + '?formFactor=' + action.context.formFactor + '&modes=View,Edit';
+  let recordViewUrl = action.creds.instanceUrl + '/services/data/v42.0/ui-api/record-ui/' + action.recordId + '?formFactor=' + action.context.formFactor + '&layoutTypes=Full&modes=View,Edit';
   
   let req = {
     method: 'GET',


### PR DESCRIPTION
Added `layoutTypes` param to `/ui-api/record-ui/{recordIds}` request to be explicit for learning purposes, and especially for people taking the UI API Trailhead module. Fixes #29.